### PR TITLE
check if all robot topics/servers are available before accepting a goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Example nodes to drive the iRobot® Create® 3 Educational Robot.
 
 ### Dependencies
 
- - ROS 2
+ - ROS 2 Galactic
  - [irobot_create_msgs](https://github.com/iRobotEducation/irobot_create_msgs)
 
 
@@ -21,3 +21,7 @@ cd ..
 colcon build
 source install/local_setup.sh
 ```
+
+### Run the examples
+
+Refer to the individual examples README.md for instructions on how to run them.

--- a/create3_coverage/README.md
+++ b/create3_coverage/README.md
@@ -23,9 +23,7 @@ ros2 action send_goal /coverage create3_examples_msgs/action/Coverage "{explore_
 
 ### Robot initial configuration
 
-Either place your robot on its dock or far from it (note: the behavior may fail or make the robot run over the dock if you start very close to it).
-
-Do not place the robot in contact with obstacles or onto a cliff.
-
-This example will check if the robot has some reflexes enabled.
-If they are not enabled, it will use simple backup maneuvers to move away from hazards.
+**NOTES:**
+ - Do not start the behavior with the robot undocked, but very close to the dock. The behavior may fail or it may cause the robot to run over its dock.
+ It's safe to start with the robot still docked.
+ - Do not start the behavior with the robot in contact with obstacles or cliffs.

--- a/create3_coverage/include/create3_coverage/create3_coverage_node.hpp
+++ b/create3_coverage/include/create3_coverage/create3_coverage_node.hpp
@@ -42,6 +42,8 @@ private:
 
     bool reflexes_setup();
 
+    bool ready_to_start();
+
     rclcpp_action::GoalResponse
     handle_goal(
         const rclcpp_action::GoalUUID& uuid,

--- a/create3_examples_py/README.md
+++ b/create3_examples_py/README.md
@@ -4,6 +4,9 @@ This package contains Python script that demonstrate how to interact with the Cr
 
 ## iRobot® Create® 3 Dance
 
+**NOTES:** 
+ - You must undock the robot before starting this example
+
 This executable will show how to drive the robot around while changing its LED colors.
 Use it to create patterns and follow the tempo of your favourite songs!
 To run it:


### PR DESCRIPTION
This PR adds a `ready_to_start` function that is checked by the coverage node before accepting a goal.
It verifies that all the needed topics/messages have been discovered.

Moreover, some minor changes to documentation.

Testing done:
 - trying to send a coverage goal request without the robot/simulator being present results in the goal being rejected
 - goals sent after the robot/simulator are present are accepted

This will address https://github.com/iRobotEducation/create3_examples/issues/8 


Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>