### PR TITLE
add teleop launch scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ mkdir -p create3_examples_ws/src
 cd create3_examples_ws/src
 git clone https://github.com/iRobotEducation/create3_examples.git
 cd ..
+rosdep install --from-path src --ignore-src -yi
 colcon build
 source install/local_setup.sh
 ```

--- a/create3_teleop/README.md
+++ b/create3_teleop/README.md
@@ -1,0 +1,33 @@
+# Create3 Teleopearation
+
+This package contains scripts and instructions for teleoperating the the Create® 3 robot using keyboard or joystick.
+
+### Keyboard Teleoperation
+
+```sh
+ros2 run teleop_twist_keyboard teleop_twist_keyboard
+```
+
+### Joystick Teleoperation
+
+```sh
+ros2 launch create3_teleop teleop_joystick_launch.py
+```
+
+This will default to an xbox 360 controller, but can be easily overriden using the `joy_config` launchfile argument for any of the supported platforms. As of time of writing, these are:
+- Logitech Attack3 (`atk3`)
+- Logitech Extreme 3D Pro (`xd3`)
+- PS3 (`ps3` or `ps3-holonomic`)
+- Xbox 360 (`xbox`)
+
+Example for a PS3 controller:
+
+```sh
+ros2 launch create3_teleop teleop_joystick_launch.py joy_config:=ps3
+```
+
+Also, it's possible to select the specific device to use with the `joy_dev` argument. It can be used as follows:
+
+```sh
+ros2 launch create3_teleop teleop_joystick_launch.py joy_dev:=/dev/input/js1
+```

--- a/create3_teleop/launch/teleop_joystick_launch.py
+++ b/create3_teleop/launch/teleop_joystick_launch.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# Copyright 2021 iRobot Corporation. All Rights Reserved.
+# @author Alexis Pojomovsky (apojomovsky@irobot.com)
+#
+# Launches a joystick teleop node.
+
+import os
+from typing import Text
+
+from ament_index_python.packages import get_package_share_directory, PackageNotFoundError
+
+from launch import LaunchContext, LaunchDescription, SomeSubstitutionsType, Substitution
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+class JoystickConfigParser(Substitution):
+    def __init__(
+        self,
+        package_name: Text,
+        device_type: SomeSubstitutionsType
+    ) -> None:
+        self.__package_name = package_name
+        self.__device_type = device_type
+
+    def perform(
+        self,
+        context: LaunchContext = None,
+    ) -> Text:
+        device_type_str = self.__device_type.perform(context)
+        package_str = self.__package_name
+        try:
+            package_share_dir = get_package_share_directory(
+                package_str)
+            config_filepath = [package_share_dir, 'config',
+                               f'{device_type_str}.config.yaml']
+            return os.path.join(*config_filepath)
+        except PackageNotFoundError:
+            raise PackageNotFoundError(package_str)
+
+
+def generate_launch_description():
+    joy_config = LaunchConfiguration('joy_config')
+    joy_dev = LaunchConfiguration('joy_dev')
+
+    # Invokes a node that interfaces a generic joystick to ROS 2.
+    joy_node = Node(package='joy', executable='joy_node', name='joy_node',
+                    parameters=[{
+                        'dev': joy_dev,
+                        'deadzone': 0.3,
+                        'autorepeat_rate': 20.0,
+                    }])
+
+    # Retrieve the path to the correct configuration .yaml depending on
+    # the joy_config argument
+    config_filepath = JoystickConfigParser('teleop_twist_joy', joy_config)
+
+    # Publish unstamped Twist message from an attached USB Joystick.
+    teleop_node = Node(package='teleop_twist_joy', executable='teleop_node',
+                       name='teleop_twist_joy_node', parameters=[config_filepath])
+
+    # Declare launchfile arguments
+    ld_args = []
+    ld_args.append(DeclareLaunchArgument('joy_config',
+                                         default_value='xbox',
+                                         choices=['xbox', 'ps3', 'ps3-holonomic', 'atk3', 'xd3']))
+    ld_args.append(DeclareLaunchArgument('joy_dev',
+                                         default_value='/dev/input/js0'))
+
+    # Define LaunchDescription variable
+    ld = LaunchDescription(ld_args)
+
+    # Add nodes to LaunchDescription
+    ld.add_action(joy_node)
+    ld.add_action(teleop_node)
+
+    return ld

--- a/create3_teleop/package.xml
+++ b/create3_teleop/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>create3_teleop</name>
+  <version>0.0.1</version>
+  <description>Example launch files for teleoperating the iRobot(R) Create(R) 3 Educational Robot.</description>
+  <maintainer email="asoragna@irobot.com">Alberto Soragna</maintainer>
+  <license>BSD</license>
+
+  <exec_depend>joy</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>teleop_twist_keyboard</exec_depend>
+  <exec_depend>teleop_twist_joy</exec_depend>
+
+  <test_depend>ament_cmake_flake8</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/create3_teleop/setup.cfg
+++ b/create3_teleop/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/create3_teleop
+[install]
+install_scripts=$base/lib/create3_teleop

--- a/create3_teleop/setup.py
+++ b/create3_teleop/setup.py
@@ -1,0 +1,26 @@
+import os
+from glob import glob
+from setuptools import setup
+
+package_name = 'create3_teleop'
+
+setup(
+    name=package_name,
+    version='0.0.1',
+    packages=[],
+    data_files=[
+        (os.path.join('share','ament_index', 'resource_index', 'packages'),
+            [os.path.join('resource', package_name)]),
+        (os.path.join('share', package_name),
+            ['package.xml']),
+        (os.path.join('share', package_name, "launch"),
+            glob(os.path.join('launch', '*launch.py'))),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='Alberto Soragna',
+    maintainer_email='asoragna@irobot.com',
+    description='Example launch files for teleoperating the iRobot(R) Create(R) 3 Educational Robot.',
+    license='BSD-3',
+    tests_require=['pytest'],
+)


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

This is the script currently in https://github.com/iRobotEducation/create3_sim/tree/main/irobot_create_toolbox/launch
I want to remove them from there as they are not specific to the simulator