### PR TITLE
Explicitly split installing vs initialization for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Example nodes to drive the iRobot® Create® 3 Educational Robot.
 
 First, source your ROS 2 workspaces with all the required dependencies.
 Then, you are ready to clone and build this repository.
+You should only have to do this once per install.
 
 ```sh
 mkdir -p create3_examples_ws/src
@@ -20,7 +21,14 @@ git clone https://github.com/iRobotEducation/create3_examples.git
 cd ..
 rosdep install --from-path src --ignore-src -yi
 colcon build
-source install/local_setup.sh
+```
+
+### Initialization instructions
+
+You will have to do this in every new session in which you wish to use these examples:
+
+```sh
+source ~/create3_examples_ws/install/local_setup.sh
 ```
 
 ### Run the examples


### PR DESCRIPTION
Pulled out sourcing setup.sh from the rest of the build instructions due to direct feedback from less experienced ROS users.