### PR TITLE
add config files and enable button launch argument

### DIFF
--- a/create3_teleop/README.md
+++ b/create3_teleop/README.md
@@ -17,10 +17,10 @@ ros2 launch create3_teleop teleop_joystick_launch.py
 This will default to an xbox 360 controller, but can be easily overriden using the `joy_config` launchfile argument for any of the supported platforms. As of time of writing, these are:
 - Logitech Attack3 (`atk3`)
 - Logitech Extreme 3D Pro (`xd3`)
-- PS3 (`ps3` or `ps3-holonomic`)
+- PS3 (`ps3`, `ps3-ble` or `ps3-holonomic`)
 - Xbox 360 (`xbox`)
 
-Example for a PS3 controller:
+Example for a PS3 controller connected via usb:
 
 ```sh
 ros2 launch create3_teleop teleop_joystick_launch.py joy_config:=ps3
@@ -30,4 +30,10 @@ Also, it's possible to select the specific device to use with the `joy_dev` argu
 
 ```sh
 ros2 launch create3_teleop teleop_joystick_launch.py joy_dev:=/dev/input/js1
+```
+
+Lastly, the enable button feature has been disabled on all joysticks by default. However, it can be re-enabled via the `joy_enable` launchfile argument:
+
+```sh
+ros2 launch create3_teleop teleop_joystick_launch.py joy_enable:='enable'
 ```

--- a/create3_teleop/config/enable.atk3.config.yaml
+++ b/create3_teleop/config/enable.atk3.config.yaml
@@ -1,0 +1,17 @@
+# Logitech Attack3
+teleop_twist_joy_node:
+  ros__parameters:
+    axis_linear:  # Forward/Back
+      x: 1
+    scale_linear:
+      x: 0.7
+    scale_linear_turbo:
+      x: 1.5
+
+    axis_angular:  # Left/Right
+      yaw: 0
+    scale_angular:
+      yaw: 0.4
+
+    enable_button: 0  # Trigger
+    enable_turbo_button: 1  # Button 2 aka thumb button

--- a/create3_teleop/config/enable.ps3-ble.config.yaml
+++ b/create3_teleop/config/enable.ps3-ble.config.yaml
@@ -1,0 +1,17 @@
+teleop_twist_joy_node:
+  ros__parameters:
+    axis_linear:
+      x: 1
+    scale_linear:
+      x: 0.7
+    scale_linear_turbo:
+      x: 1.5
+
+    axis_angular:
+      yaw: 0
+    scale_angular:
+      yaw: 0.4
+#button mapping for ps3 controller connected via bluetooth
+    enable_button: 8  # L2 shoulder button
+    enable_turbo_button: 10  # L1 shoulder button
+    #require_enable_button: false

--- a/create3_teleop/config/enable.ps3-holonomic.config.yaml
+++ b/create3_teleop/config/enable.ps3-holonomic.config.yaml
@@ -1,0 +1,14 @@
+teleop_twist_joy_node:
+  ros__parameters:
+    axis_linear:
+      x: 1
+      y: 0
+    scale_linear:
+      x: 0.4
+      y: 0.4
+    axis_angular:
+      yaw: 2
+    scale_angular:
+      yaw: 0.5
+    enable_button: 10
+    enable_turbo_button: 8

--- a/create3_teleop/config/enable.ps3.config.yaml
+++ b/create3_teleop/config/enable.ps3.config.yaml
@@ -1,0 +1,17 @@
+teleop_twist_joy_node:
+  ros__parameters:
+    axis_linear:
+      x: 1
+    scale_linear:
+      x: 0.7
+    scale_linear_turbo:
+      x: 1.5
+
+    axis_angular:
+      yaw: 0
+    scale_angular:
+      yaw: 0.4
+#button mapping for ps3 controller connected via usb
+    enable_button: 6 # L2 shoulder button
+    enable_turbo_button: 4  # L1 shoulder button
+    #require_enable_button: false

--- a/create3_teleop/config/enable.xbox.config.yaml
+++ b/create3_teleop/config/enable.xbox.config.yaml
@@ -1,0 +1,16 @@
+teleop_twist_joy_node:
+  ros__parameters:
+    axis_linear:  # Left thumb stick vertical
+      x: 1
+    scale_linear:
+      x: 0.7
+    scale_linear_turbo:
+      x: 1.5
+
+    axis_angular:  # Left thumb stick horizontal
+      yaw: 0
+    scale_angular:
+      yaw: 0.4
+
+    enable_button: 2  # Left trigger button
+    enable_turbo_button: 5  # Right trigger button

--- a/create3_teleop/config/enable.xd3.config.yaml
+++ b/create3_teleop/config/enable.xd3.config.yaml
@@ -1,0 +1,17 @@
+# Logitech Extreme 3D Pro
+teleop_twist_joy_node:
+  ros__parameters:
+    axis_linear:  # Forward/Back
+      x: 1
+    scale_linear:
+      x: 0.7
+    scale_linear_turbo:
+      x: 1.5
+
+    axis_angular:  # Twist
+      yaw: 2
+    scale_angular:
+      yaw: 0.4
+
+    enable_button: 0  # Trigger
+    enable_turbo_button: 1  # Button 2 aka thumb button

--- a/create3_teleop/config/no-enable.atk3.config.yaml
+++ b/create3_teleop/config/no-enable.atk3.config.yaml
@@ -1,0 +1,18 @@
+# Logitech Attack3
+teleop_twist_joy_node:
+  ros__parameters:
+    axis_linear:  # Forward/Back
+      x: 1
+    scale_linear:
+      x: 0.7
+    scale_linear_turbo:
+      x: 1.5
+
+    axis_angular:  # Left/Right
+      yaw: 0
+    scale_angular:
+      yaw: 0.4
+
+    #enable_button: 0  # Trigger
+    enable_turbo_button: 1  # Button 2 aka thumb button
+    require_enable_button: false

--- a/create3_teleop/config/no-enable.ps3-ble.config.yaml
+++ b/create3_teleop/config/no-enable.ps3-ble.config.yaml
@@ -1,0 +1,17 @@
+teleop_twist_joy_node:
+  ros__parameters:
+    axis_linear:
+      x: 1
+    scale_linear:
+      x: 0.7
+    scale_linear_turbo:
+      x: 1.5
+
+    axis_angular:
+      yaw: 0
+    scale_angular:
+      yaw: 0.4
+
+    #enable_button: 8  # L2 shoulder button
+    enable_turbo_button: 10  # L1 shoulder button
+    require_enable_button: false

--- a/create3_teleop/config/no-enable.ps3-holonomic.config.yaml
+++ b/create3_teleop/config/no-enable.ps3-holonomic.config.yaml
@@ -1,0 +1,15 @@
+teleop_twist_joy_node:
+  ros__parameters:
+    axis_linear:
+      x: 1
+      y: 0
+    scale_linear:
+      x: 0.4
+      y: 0.4
+    axis_angular:
+      yaw: 2
+    scale_angular:
+      yaw: 0.5
+    #enable_button: 10
+    enable_turbo_button: 8
+    require_enable_button: false

--- a/create3_teleop/config/no-enable.ps3.config.yaml
+++ b/create3_teleop/config/no-enable.ps3.config.yaml
@@ -1,0 +1,17 @@
+teleop_twist_joy_node:
+  ros__parameters:
+    axis_linear:
+      x: 1
+    scale_linear:
+      x: 0.7
+    scale_linear_turbo:
+      x: 1.5
+
+    axis_angular:
+      yaw: 0
+    scale_angular:
+      yaw: 0.4
+#button mapping for ps3 controller connected via usb
+    #enable_button: 6  # L2 shoulder button
+    enable_turbo_button: 4  # L1 shoulder button
+    require_enable_button: false

--- a/create3_teleop/config/no-enable.xbox.config.yaml
+++ b/create3_teleop/config/no-enable.xbox.config.yaml
@@ -1,0 +1,17 @@
+teleop_twist_joy_node:
+  ros__parameters:
+    axis_linear:  # Left thumb stick vertical
+      x: 1
+    scale_linear:
+      x: 0.7
+    scale_linear_turbo:
+      x: 1.5
+
+    axis_angular:  # Left thumb stick horizontal
+      yaw: 0
+    scale_angular:
+      yaw: 0.4
+
+    #enable_button: 2  # Left trigger button
+    enable_turbo_button: 5  # Right trigger button
+    require_enable_button: false

--- a/create3_teleop/config/no-enable.xd3.config.yaml
+++ b/create3_teleop/config/no-enable.xd3.config.yaml
@@ -1,0 +1,18 @@
+# Logitech Extreme 3D Pro
+teleop_twist_joy_node:
+  ros__parameters:
+    axis_linear:  # Forward/Back
+      x: 1
+    scale_linear:
+      x: 0.7
+    scale_linear_turbo:
+      x: 1.5
+
+    axis_angular:  # Twist
+      yaw: 2
+    scale_angular:
+      yaw: 0.4
+
+    #enable_button: 0  # Trigger
+    enable_turbo_button: 1  # Button 2 aka thumb button
+    require_enable_button: false

--- a/create3_teleop/launch/teleop_joystick_launch.py
+++ b/create3_teleop/launch/teleop_joystick_launch.py
@@ -19,22 +19,25 @@ class JoystickConfigParser(Substitution):
     def __init__(
         self,
         package_name: Text,
-        device_type: SomeSubstitutionsType
+        device_type: SomeSubstitutionsType,
+        enable_set: SomeSubstitutionsType
     ) -> None:
         self.__package_name = package_name
         self.__device_type = device_type
+        self.__enable_set = enable_set
 
     def perform(
         self,
         context: LaunchContext = None,
     ) -> Text:
         device_type_str = self.__device_type.perform(context)
+        enable_set_str = self.__enable_set.perform(context)
         package_str = self.__package_name
         try:
             package_share_dir = get_package_share_directory(
                 package_str)
             config_filepath = [package_share_dir, 'config',
-                               f'{device_type_str}.config.yaml']
+                               f'{enable_set_str}.{device_type_str}.config.yaml']
             return os.path.join(*config_filepath)
         except PackageNotFoundError:
             raise PackageNotFoundError(package_str)
@@ -43,6 +46,7 @@ class JoystickConfigParser(Substitution):
 def generate_launch_description():
     joy_config = LaunchConfiguration('joy_config')
     joy_dev = LaunchConfiguration('joy_dev')
+    joy_enable = LaunchConfiguration('joy_enable')
 
     # Invokes a node that interfaces a generic joystick to ROS 2.
     joy_node = Node(package='joy', executable='joy_node', name='joy_node',
@@ -54,7 +58,7 @@ def generate_launch_description():
 
     # Retrieve the path to the correct configuration .yaml depending on
     # the joy_config argument
-    config_filepath = JoystickConfigParser('teleop_twist_joy', joy_config)
+    config_filepath = JoystickConfigParser('create3_teleop', joy_config, joy_enable)
 
     # Publish unstamped Twist message from an attached USB Joystick.
     teleop_node = Node(package='teleop_twist_joy', executable='teleop_node',
@@ -64,10 +68,12 @@ def generate_launch_description():
     ld_args = []
     ld_args.append(DeclareLaunchArgument('joy_config',
                                          default_value='xbox',
-                                         choices=['xbox', 'ps3', 'ps3-holonomic', 'atk3', 'xd3']))
+                                         choices=['ps3-ble', 'xbox', 'ps3', 'ps3-holonomic', 'atk3', 'xd3']))
     ld_args.append(DeclareLaunchArgument('joy_dev',
                                          default_value='/dev/input/js0'))
-
+    ld_args.append(DeclareLaunchArgument('joy_enable',
+                                         default_value='no-enable',
+                                         choices=['no-enable', 'enable']))
     # Define LaunchDescription variable
     ld = LaunchDescription(ld_args)
 

--- a/create3_teleop/launch/teleop_joystick_launch.py
+++ b/create3_teleop/launch/teleop_joystick_launch.py
@@ -71,6 +71,7 @@ def generate_launch_description():
                                          choices=['ps3-ble', 'xbox', 'ps3', 'ps3-holonomic', 'atk3', 'xd3']))
     ld_args.append(DeclareLaunchArgument('joy_dev',
                                          default_value='/dev/input/js0'))
+    # Launch argument to set enable button
     ld_args.append(DeclareLaunchArgument('joy_enable',
                                          default_value='no-enable',
                                          choices=['no-enable', 'enable']))

--- a/create3_teleop/setup.py
+++ b/create3_teleop/setup.py
@@ -15,6 +15,7 @@ setup(
             ['package.xml']),
         (os.path.join('share', package_name, "launch"),
             glob(os.path.join('launch', '*launch.py'))),
+        (os.path.join('share', package_name, 'config'), glob('config/*.yaml')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
I've duplicated the config yaml files from the teleop_twist_joy package adding an additional file to differentiate the ps3 via usb from the ps3 via bluetooth because the mappings are different between the two. I've added a config file that has the enable button requirement set to true and one set to false for each of the joystick configurations. This config is set by the new launch argument `joy_enable`. Lastly, I updated the setup.py file to create and populate a config folder with necessary config files during install. 