### PR TITLE
Remove name for rplidar_node

### DIFF
--- a/create3_lidar_slam/launch/sensors_launch.py
+++ b/create3_lidar_slam/launch/sensors_launch.py
@@ -9,24 +9,24 @@ from ament_index_python.packages import get_package_share_directory
 
 
 def generate_launch_description():
-    # Evaluate at launch the value of the launch configuration 'namespace' 
+    # Evaluate at launch the value of the launch configuration 'namespace'
     namespace = LaunchConfiguration('namespace')
 
-    # Declares an action to allow users to pass the robot namespace from the 
+    # Declares an action to allow users to pass the robot namespace from the
     # CLI into the launch description as an argument.
     namespace_argument = DeclareLaunchArgument(
-        'namespace', 
+        'namespace',
         default_value='',
         description='Robot namespace')
-    
+
     # Declares an action that will launch a node when executed by the launch description.
     # This node is responsible for providing a static transform from the robot's base_footprint
-    # frame to a new laser_frame, which will be the coordinate frame for the lidar. 
+    # frame to a new laser_frame, which will be the coordinate frame for the lidar.
     static_transform_node = Node(
-        package='tf2_ros', 
+        package='tf2_ros',
         executable='static_transform_publisher',
         arguments=['-0.012', '0', '0.144', '0', '0', '0', 'base_footprint', 'laser_frame'],
-        
+
         # Remaps topics used by the 'tf2_ros' package from absolute (with slash) to relative (no slash).
         # This is necessary to use namespaces with 'tf2_ros'.
         remappings=[
@@ -34,11 +34,10 @@ def generate_launch_description():
             ('/tf', 'tf')],
         namespace=namespace
     )
-    
+
     # Declares an action that will launch a node when executed by the launch description.
-    # This node is responsible for configuring the RPLidar sensor.    
+    # This node is responsible for configuring the RPLidar sensor.
     rplidar_node = Node(
-        name='rplidar_composition',
         package='rplidar_ros',
         executable='rplidar_composition',
         output='screen',
@@ -47,7 +46,7 @@ def generate_launch_description():
             ],
         namespace=namespace
     )
-    
+
     # Launches all named actions
     return LaunchDescription([
         namespace_argument,


### PR DESCRIPTION
The node is named by the configuration; it should not be renamed here.

There's a lot of spam in the diff thanks to automatic whitespace removal. Sorry about that.