### PR TITLE
Turtlebot4 Republisher

### DIFF
--- a/create3_republisher/bringup/params.yaml
+++ b/create3_republisher/bringup/params.yaml
@@ -10,10 +10,10 @@
       robot_publishers: [
         "battery_state", "sensor_msgs/msg/BatteryState",
       # "cliff_intensity", "irobot_create_msgs/msg/IrIntensityVector",
-      # "dock_status", "irobot_create_msgs/msg/DockStatus",
+        "dock_status", "irobot_create_msgs/msg/DockStatus",
       # "hazard_detection", "irobot_create_msgs/msg/HazardDetectionVector",
         "imu", "sensor_msgs/msg/Imu",
-      # "interface_buttons", "irobot_create_msgs/msg/InterfaceButtons",
+        "interface_buttons", "irobot_create_msgs/msg/InterfaceButtons",
       # "ir_intensity", "irobot_create_msgs/msg/IrIntensityVector",
       # "ir_opcode", "irobot_create_msgs/msg/IrOpcode",
       # "kidnap_status", "irobot_create_msgs/msg/KidnapStatus",
@@ -23,7 +23,7 @@
       # "stop_status", "irobot_create_msgs/msg/StopStatus",
         "tf", "tf2_msgs/msg/TFMessage",
         "tf_static", "tf2_msgs/msg/TFMessage",
-      # "wheel_status", "irobot_create_msgs/msg/WheelStatus",
+        "wheel_status", "irobot_create_msgs/msg/WheelStatus",
       # "wheel_ticks", "irobot_create_msgs/msg/WheelTicks",
       # "wheel_vels", "irobot_create_msgs/msg/WheelVels",
       ]

--- a/create3_republisher/republisher.cpp
+++ b/create3_republisher/republisher.cpp
@@ -346,10 +346,11 @@ private:
         if (robot_namespace.empty()) {
             throw std::runtime_error("The 'robot_namespace' parameter can't be an empty string");
         }
-        if (robot_namespace[0] != '/') {
-            throw std::runtime_error("The 'robot_namespace' parameter must be a fully qualified name (start with '/')");
-        }
         const std::string this_namespace = this->get_namespace();
+        if (robot_namespace[0] != '/') {
+            // If the robot namespace is not fully qualified, make it relative to this node's namespace
+            robot_namespace = this_namespace + "/" + robot_namespace;
+        }
         if (robot_namespace == this->get_namespace()) {
             throw std::runtime_error("The republisher node must have a different namespace from the robot!");
         }


### PR DESCRIPTION
1. Allow for a relative robot namespace. Instead of causing an error, it will use the node namespace as a parent to fully qualify the robot namespace. This is desirable for Turtlebot4 because the namespace is pushed in a parent launch file relative to where the republisher is launched ([launch file](https://github.com/turtlebot/turtlebot4_robot/blob/24c7180f67273a5ee3ed305e91f6dc3b780233b5/turtlebot4_bringup/launch/robot.launch.py#L76)).
2. Added 3 more topics to be enabled by default - if you disagree with this then I can put a copy of this params.yaml in the Turtlebot4 Robot package that launches the republisher. These topics are required for base Turtlebot4 functionality. 