### PR TITLE
Relative Namespace Fix

### DIFF
--- a/create3_republisher/republisher.cpp
+++ b/create3_republisher/republisher.cpp
@@ -370,11 +370,6 @@ private:
         if (robot_namespace.empty()) {
             throw std::runtime_error("The 'robot_namespace' parameter can't be an empty string");
         }
-        const std::string this_namespace = this->get_namespace();
-        if (robot_namespace[0] != '/') {
-            // If the robot namespace is not fully qualified, make it relative to this node's namespace
-            robot_namespace = this_namespace + "/" + robot_namespace;
-        }
         if (robot_namespace == this->get_namespace()) {
             throw std::runtime_error("The republisher node must have a different namespace from the robot!");
         }


### PR DESCRIPTION
Remove manual handling of namespace not being fully qualified

Currently the code only allows the relative namespace if there is a republisher namespace, this would remove all restrictions / manual control on relative namespacing and revert it to being handled by ROS. 

Fix required for Turtlebot4 standard packages